### PR TITLE
Create a modifier for the Mars Weather Title that can be reused in other parts of the app

### DIFF
--- a/MarsWeather/Modifiers/MarsTitleModifier.swift
+++ b/MarsWeather/Modifiers/MarsTitleModifier.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct MarsTitle: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+        .font(.largeTitle)
+        .fontWeight(.semibold)
+        .foregroundStyle(
+            LinearGradient(
+                colors: [.orange,
+                         .accentColor],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+    }
+}
+
+extension View {
+    func marsTitle() -> some View {
+        modifier(MarsTitle())
+    }
+}

--- a/MarsWeather/Views/HeaderView.swift
+++ b/MarsWeather/Views/HeaderView.swift
@@ -12,7 +12,8 @@ struct HeaderView: View {
     
     var body: some View {
         HStack {
-            AppTitleView()
+            Text("Mars Weather")
+              .marsTitle()
             
             Spacer()
             


### PR DESCRIPTION
Instead of using `AppTitleView` I created modifier that can be reused to decorate Text in other parts of the code if that comes around.

Observe that I left the `AppTitleView` swift file in the code as I did not want this PR to mess too much with the original project.